### PR TITLE
Fix liquid tags

### DIFF
--- a/docs/getting-started/install-pagebuilder.md
+++ b/docs/getting-started/install-pagebuilder.md
@@ -1,8 +1,8 @@
 # Install Page Builder
 
->[!NOTE]
->These installation instructions are only for contributors to the Page Builder code or documentation. 
->For everyone else, Page Builder is automatically installed with Magento Commerce 2.3.1. There is nothing else you need to do.
+{: .bs-callout-info }
+These installation instructions are only for contributors to the Page Builder code or documentation.
+For everyone else, Page Builder is automatically installed with Magento Commerce 2.3.1. There is nothing else you need to do.
 
 ## GitHub installation for Contributors
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -3,8 +3,8 @@
 We wrote Page Builder in [TypeScript], a superset of JavaScript. Before each release, we transpile the TypeScript to JavaScript.
 Use the TypeScript components in the module as a reference to understand the flow of information.
 
->[!NOTE]
->You need not use TypeScript in your module to work with the Page Builder code.
+{: .bs-callout-info }
+You need not use TypeScript in your module to work with the Page Builder code.
 
 Page Builder also uses core Magento technologies such as jQuery, Knockout, and UI Components, along with additional libraries to help with various content types shipped with the module.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -3,7 +3,7 @@
 We wrote Page Builder in [TypeScript], a superset of JavaScript. Before each release, we transpile the TypeScript to JavaScript.
 Use the TypeScript components in the module as a reference to understand the flow of information.
 
->[!NOTE] 
+>[!NOTE]
 >You need not use TypeScript in your module to work with the Page Builder code.
 
 Page Builder also uses core Magento technologies such as jQuery, Knockout, and UI Components, along with additional libraries to help with various content types shipped with the module.
@@ -13,10 +13,12 @@ Page Builder also uses core Magento technologies such as jQuery, Knockout, and U
 Page Builder uses XHTML with inline styles and data attributes for storage and as the master format.
 This allows Page Builder to display content with minimum changes to the Magento storefront and other third-party systems.
 Use the following steps to display Page Builder content on a Magento storefront or third-party system:
+{% raw %}
 
 1. Replace all Magento directives such as `{{image url=path/to/image.png}}`
 2. Add custom stylesheet to provide the base styles that the user can't edit. This includes styles for the content types, such as the `slider` and the `tabs`.
 3. After the content renders, load and initialize the widgets and libraries on the frontend that need initialization, such as the `slider` and the `tabs`.
+{% endraw %}
 
 ## Integration with Magento and custom modules
 
@@ -118,8 +120,8 @@ For example:
 
 ```xml
 <element name="main">
-	<style name="display" source="display" 
-           converter="Magento_PageBuilder/js/converter/style/display" 
+	<style name="display" source="display"
+           converter="Magento_PageBuilder/js/converter/style/display"
            preview_converter="Magento_PageBuilder/js/converter/style/preview/display"/>
 </element>
 ```

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,5 +1,6 @@
 # Page Builder events
 
+{% raw %}
 The pattern for consuming Page Builder events in JavaScript, such as within the `preview.js` component, is to import `Magento_PageBuilder/js/events` and use the `events.on()` method to bind to the event you want to handle, as shown here:
 
 ```js
@@ -478,3 +479,5 @@ events.on("googleMaps:authFailure", function () {});
 [Back to top]
 
 [Back to top]: #events-list
+
+{% endraw %}

--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,7 @@
         "path": "",
         "pages": [
           {
-            "title": "Create a Public Key Certificate",
+            "title": "Overview",
             "path": "magento/magento2-page-builder-docs/master/docs/extend-existing-content-type/overview.md",
             "pages": []
           },


### PR DESCRIPTION
This PR fixes a liquid tag parsing errors in the main devdocs pipeline by adding ignore tags around the offending double curly brackets.